### PR TITLE
metabase -> metabase_origin | metabase_destination

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     networks:
       - metanet1
     depends_on:
-      - metabase
+      - metabase_origin
     command: sh /tmp/metabase-setup.sh metabase_origin:3000
     cpus: 1
     mem_limit: 128m
@@ -73,7 +73,7 @@ services:
     networks:
       - metanet2
     depends_on:
-      - metabase
+      - metabase_destination
     command: sh /tmp/metabase-setup.sh metabase_destination:3000
     cpus: 1
     mem_limit: 128m


### PR DESCRIPTION
`docker-compose up` doesn't work because the `metabase` service doesn't exist, which is referenced in `setup_origin` and `setup_destination`. I think these changes are what you meant to write.